### PR TITLE
Add parquet as a writer / datasource type to reth-indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +239,7 @@ checksum = "963fef509b757bcbbf9e5ffa23bcb345614d99f4f6f531f97417b27b8604d389"
 dependencies = [
  "ahash 0.8.3",
  "arrow-format",
+ "base64 0.21.2",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -231,6 +247,7 @@ dependencies = [
  "ethnum",
  "fallible-streaming-iterator",
  "foreign_vec",
+ "futures",
  "getrandom",
  "hash_hasher",
  "hashbrown 0.14.0",
@@ -238,6 +255,7 @@ dependencies = [
  "lz4",
  "multiversion",
  "num-traits",
+ "parquet2",
  "regex",
  "regex-syntax 0.7.5",
  "rustc_version",
@@ -375,7 +393,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -538,6 +556,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "brotli"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -820,6 +859,15 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "critical-section"
@@ -1313,6 +1361,16 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2232,6 +2290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2602,34 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "parquet-format-safe"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1131c54b167dd4e4799ce762e1ab01549ebb94d5bdd13e6ec1b467491c378e1f"
+dependencies = [
+ "async-trait",
+ "futures",
+]
+
+[[package]]
+name = "parquet2"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579fe5745f02cef3d5f236bfed216fd4693e49e4e920a13475c6132233283bce"
+dependencies = [
+ "async-stream",
+ "brotli",
+ "flate2",
+ "futures",
+ "lz4",
+ "parquet-format-safe",
+ "seq-macro",
+ "snap",
+ "streaming-decompression",
+ "zstd",
 ]
 
 [[package]]
@@ -4087,6 +4182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+
+[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,6 +4500,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-decompression"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6cc3b19bfb128a8ad11026086e31d3ce9ad23f8ea37354b31383a187c44cf3"
+dependencies = [
+ "fallible-streaming-iterator",
+]
 
 [[package]]
 name = "streaming-iterator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ jemalloc-ctl = { version = "0.5.0", optional = true }
 phf = { version = "0.11.2", features = ["macros"] }
 indexmap = "2.0.0"
 serde_with = "3.3.0"
-polars = { version = "0.33.0", features = ["dtype-datetime", "lazy", "describe", "serde", "json", "temporal"]}
+polars = { version = "0.33.0", features = ["dtype-datetime", "lazy", "describe", "serde", "json", "temporal", "parquet"]}
 chrono = "0.4.31"
 once_cell = "1.18.0"
 async-trait = "0.1.74"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # reth-indexer
 
-reth-indexer reads directly from the reth db and indexes the data into traditional and alternative databases / datastores (postgres, GCP bigquery, etc) all decoded with a simple config file and no extra setup alongside exposing a API ready to query the data.
+reth-indexer reads directly from the reth db and indexes the data into traditional and alternative databases / datastores (postgres, GCP bigquery, parquet, etc) all decoded with a simple config file and no extra setup alongside exposing a API ready to query the data.
 
 <img src="./assets/demo.gif" />
 
@@ -20,9 +20,9 @@ This tool is perfect for all kinds of people from developers, to data anaylsis, 
 
 ## Features
 
-- Creates database tables for you automatically (postgres, gcp biquery, or others)
+- Creates database tables for you automatically (postgres, gcp biquery, parquet, or others)
 - Creates indexes on the tables for you automatically to allow you to query the data fast
-- Can write index to multiple data stores (i.e. postgres, gcp bigquery, etc)
+- Can write index to multiple data stores (i.e. postgres, gcp bigquery, parquet, etc)
 - Indexes any events from the reth node db
 - Supports indexing any events from multiple contracts or all contracts at the same time
 - Supports filtering even on the single input types so allowing you to filter on every element of the event
@@ -255,6 +255,28 @@ GCP bigquery dataset id (i.e. database / schema)
 #### credentialsPath
 
 Path to GCP credentials file (JSON) - this would contain the executing user / account credentials within GCP environment
+
+### parquet - optional (only if writing locally to parquet format)
+
+Holds parquet writer information and settings (written to locally-accessible drive / mount)
+
+
+example:
+
+```json
+"parquet": {
+   "dropTableBeforeSync": true,
+   "dataDirectory": "/path/to/data/sync/root"
+}
+```
+
+#### dropTableBeforeSync - required
+
+if true, will delete the subdirectories for the target tables holding parquet files (if exists).
+
+#### dataDirectory - required
+
+root / base directory. note that each event type indexed will have its own directory within the root directory (dataDirectory)
 
 ### eventMappings
 

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -1,12 +1,133 @@
-use crate::csv::CsvWriter;
+use crate::{csv::CsvWriter, types::IndexerContractMapping};
 use async_trait::async_trait;
-use std::any::Any;
 
-///
+use csv::ReaderBuilder;
+use indexmap::IndexMap;
+use phf::phf_ordered_map;
+use polars::prelude::*;
+use std::{any::Any, collections::HashMap, fs::File};
+
 ///  Common trait for writeable datasources
-///  This interface will be implemented by
+///  This interface will be implemented by each writer to allow for
+///  
 #[async_trait]
 pub trait DatasourceWritable {
     async fn write_data(&self, table_name: &str, csv_writer: &CsvWriter);
     fn as_any(&self) -> &dyn Any;
+}
+
+/// Columns common to all tablesi
+/// Each table's columns will include the following commmon fields
+///
+pub static COMMON_COLUMNS: phf::OrderedMap<&'static str, &'static str> = phf_ordered_map! {
+    "indexed_id" => "string",  // will need to generate uuid in rust; postgres allows for autogenerate
+    "contract_address" => "string",
+    "tx_hash" => "string",
+    "block_number" => "int",
+    "block_hash" => "string",
+    "timestamp" => "int"
+};
+
+///
+/// This function merges the common columns specified in COMMON_COLUMNS with the
+/// columns specified in the reth-indexer-config file for the particular event type to parse
+/// The types are ordered to allow for consistent column order within the GCP tables
+/// This is done for each table specified in the indexer
+///
+/// # Arguments
+///
+/// * `indexer_event_mappings` - list of all event mappings
+pub fn load_table_configs(
+    indexer_event_mappings: &[IndexerContractMapping],
+) -> HashMap<String, IndexMap<String, String>> {
+    //  Config map for all tables
+    //  Ordered by common columns, then by configured mapped
+    let mut all_tables: HashMap<String, IndexMap<String, String>> = HashMap::new();
+
+    for mapping in indexer_event_mappings {
+        for abi_item in mapping.decode_abi_items.iter() {
+            let table_name = abi_item.name.to_lowercase();
+            let column_type_map: IndexMap<String, String> = abi_item
+                .inputs
+                .iter()
+                .map(|input| {
+                    (
+                        input.name.clone(),
+                        solidity_type_to_db_type(input.type_.clone().as_str()).to_string(),
+                    )
+                })
+                .collect();
+
+            let common_column_type_map: IndexMap<String, String> = COMMON_COLUMNS
+                .into_iter()
+                .map(|it| (it.0.to_string(), it.1.to_string()))
+                .collect();
+
+            let merged_column_types: IndexMap<String, String> = common_column_type_map
+                .into_iter()
+                .chain(column_type_map)
+                .collect();
+
+            all_tables.insert(table_name, merged_column_types);
+        }
+    }
+
+    all_tables
+}
+
+///
+/// Maps solidity types (in indexer config) to a placeholder type
+/// The configuration / reth uses solidity types, we map these basic types
+/// to an equivalent bigquery type further downstream
+///
+/// # Arguments
+///
+/// * `abi_type` - the ABI type, specified as a string
+pub fn solidity_type_to_db_type(abi_type: &str) -> &str {
+    match abi_type {
+        "address" => "string",
+        "bool" | "bytes" | "string" | "int256" | "uint256" => "string",
+        "uint8" | "uint16" | "uint32" | "uint64" | "uint128" | "int8" | "int16" | "int32"
+        | "int64" | "int128" => "int",
+        _ => panic!("Unsupported type {}", abi_type),
+    }
+}
+
+///
+/// Read CSV to Polars dataframe
+/// Given CSV file, read into type-enforce polars dataframe
+/// We enforce the type of the column based on the table configuration rather than
+/// utilize polars defaults, due to the large numbers involved in some values
+/// Polars' default type imputation will yield wrong values
+///
+/// # Arguments
+///
+/// * `table_name` - name of table for dataset
+/// * `path` - path to csv file
+pub fn read_csv_to_polars(path: &str, column_map: &IndexMap<String, String>) -> DataFrame {
+    //  Get list of columns in order, from csv file
+    let file = File::open(path).unwrap();
+    let mut rdr = ReaderBuilder::new().has_headers(true).from_reader(file);
+    let headers = rdr.headers().unwrap();
+    let column_names: Vec<String> = headers.iter().map(String::from).collect();
+
+    //  Build column data types for polars dataframe, from column mapping
+    let plr_col_types = Some(Arc::new(
+        column_names
+            .iter()
+            .map(|name| match column_map[name].as_str() {
+                "int" => Field::new(name, DataType::Int64),
+                "string" => Field::new(name, DataType::Utf8),
+                _ => panic!("incompatible type found"),
+            })
+            .collect(),
+    ));
+
+    //  Read polars dataframe, w/ specified schema
+    CsvReader::from_path(path)
+        .expect("file does not exist")
+        .has_header(true)
+        .with_schema(plr_col_types)
+        .finish()
+        .unwrap()
 }

--- a/src/datasource.rs
+++ b/src/datasource.rs
@@ -58,13 +58,9 @@ pub fn load_table_configs(
                 })
                 .collect();
 
-            let common_column_type_map: IndexMap<String, String> = COMMON_COLUMNS
+            let merged_column_types: IndexMap<String, String> = COMMON_COLUMNS
                 .into_iter()
                 .map(|it| (it.0.to_string(), it.1.to_string()))
-                .collect();
-
-            let merged_column_types: IndexMap<String, String> = common_column_type_map
-                .into_iter()
                 .chain(column_type_map)
                 .collect();
 

--- a/src/gcp_bigquery.rs
+++ b/src/gcp_bigquery.rs
@@ -13,7 +13,6 @@ use gcp_bigquery_client::{
     Client,
 };
 use indexmap::IndexMap;
-// use phf::phf_ordered_map;
 use polars::prelude::*;
 use serde_json::Value;
 use std::{any::Any, collections::HashMap};

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -17,6 +17,7 @@ use crate::{
     datasource::DatasourceWritable,
     decode_events::{abi_item_to_topic_id, decode_logs, DecodedLog},
     gcp_bigquery::init_gcp_bigquery_db,
+    parquet::init_parquet_db,
     postgres::{generate_event_table_indexes, init_postgres_db, PostgresClient},
     provider::get_reth_factory,
     types::{IndexerConfig, IndexerContractMapping},
@@ -203,6 +204,13 @@ pub async fn init_datasource_writers(
                 .await
                 .expect("Failed to initialize bigquery client");
         writers.push(Box::new(bigquery_db_client));
+    }
+
+    if let Some(parquet_conf) = &indexer_config.parquet {
+        let parquet_client = init_parquet_db(parquet_conf, &indexer_config.event_mappings)
+            .await
+            .expect("Failed to initialize parquet client");
+        writers.push(Box::new(parquet_client));
     }
 
     if writers.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod datasource;
 mod decode_events;
 mod gcp_bigquery;
 mod indexer;
+mod parquet;
 mod postgres;
 mod provider;
 mod types;

--- a/src/parquet.rs
+++ b/src/parquet.rs
@@ -174,9 +174,9 @@ impl ParquetClient {
     }
 
     fn get_parquet_file_name(&self, table_name: &str, min: i64, max: i64) -> (String, String) {
-        let parquet_file_name = format!("{}___{}_{}", table_name, min, max);
+        let parquet_file_name = format!("{}___{}_{}.parquet", table_name, min, max);
         let full_path_name = format!(
-            "{}/{}/{}.parquet",
+            "{}/{}/{}",
             self.data_directory, table_name, parquet_file_name
         );
         println!("Writing parquet file: {}", full_path_name);

--- a/src/parquet.rs
+++ b/src/parquet.rs
@@ -1,12 +1,208 @@
 use crate::{
     csv::CsvWriter,
-    datasource::DatasourceWritable,
-    types::{IndexerContractMapping, IndexerGcpBigQueryConfig},
+    datasource::{load_table_configs, read_csv_to_polars, DatasourceWritable},
+    types::{IndexerContractMapping, IndexerParquetConfig},
 };
 use async_trait::async_trait;
-use csv::ReaderBuilder;
 use indexmap::IndexMap;
-use phf::phf_ordered_map;
 use polars::prelude::*;
-use serde_json::Value;
-use std::{any::Any, collections::HashMap, error::Error, fs::File};
+use std::{any::Any, collections::HashMap, error::Error, fs, fs::File, path::Path};
+
+pub struct ParquetClient {
+    data_directory: String,
+    drop_tables: bool,
+    use_pyarrow: bool,
+    table_map: HashMap<String, IndexMap<String, String>>,
+}
+
+#[derive(Debug)]
+pub enum ParquetClientError {
+    ParquetOperationError(String),
+}
+
+///
+/// Factory function to initialize parquet client
+/// Will clean up files recursively (if drop_tables is true)
+///
+/// # Arguments
+/// * `indexer_parquet_config` - parquet config settings
+/// * `event_mappings` - list of events and abi fields to parse
+pub async fn init_parquet_db(
+    indexer_parquet_config: &IndexerParquetConfig,
+    event_mappings: &[IndexerContractMapping],
+) -> Result<ParquetClient, ParquetClientError> {
+    let parquet_client = ParquetClient::new(indexer_parquet_config, event_mappings).await?;
+
+    if indexer_parquet_config.drop_tables {
+        let res = parquet_client.delete_tables().await;
+        match res {
+            Ok(..) => {}
+            Err(err) => {
+                return Err(ParquetClientError::ParquetOperationError(format!(
+                    "Parquet client operation error: {:?}",
+                    err
+                )))
+            }
+        }
+    }
+
+    let res = parquet_client.create_tables().await;
+    match res {
+        Ok(..) => {}
+        Err(err) => {
+            return Err(ParquetClientError::ParquetOperationError(format!(
+                "Parquet client operation error: {:?}",
+                err
+            )))
+        }
+    }
+
+    Ok(parquet_client)
+}
+
+impl ParquetClient {
+    ///
+    /// Create new ParquetClient, which includes root directory
+    ///
+    /// # Arguments
+    ///
+    /// * indexer_parquet_config:
+    /// * indexer_contract_mappings:
+    ///
+    pub async fn new(
+        indexer_parquet_config: &IndexerParquetConfig,
+        indexer_contract_mappings: &[IndexerContractMapping],
+    ) -> Result<Self, ParquetClientError> {
+        let table_map = load_table_configs(indexer_contract_mappings);
+
+        // Check data directory exists - if not, then create!
+        let root_data_dir: &Path = Path::new(indexer_parquet_config.data_directory.as_str());
+        if !root_data_dir.exists() {
+            let res = fs::create_dir(root_data_dir);
+            match res {
+                Ok(()) => {}
+                Err(err) => {
+                    return Err(ParquetClientError::ParquetOperationError(format!(
+                        "Could not create root dir. err: {}",
+                        err
+                    )))
+                }
+            }
+        }
+
+        Ok(ParquetClient {
+            data_directory: indexer_parquet_config.data_directory.to_string(),
+            drop_tables: indexer_parquet_config.drop_tables,
+            use_pyarrow: indexer_parquet_config.use_py_arrow,
+            table_map,
+        })
+    }
+
+    ///
+    /// Deletes "tables" as specified in the event mapping configuration
+    /// These are just subdirs that contain the synced files for that table / event
+    ///
+    pub async fn delete_tables(&self) -> Result<(), Box<dyn Error>> {
+        if self.drop_tables {
+            for table_name in self.table_map.keys() {
+                let table_dir = format!("{}/{}/", self.data_directory, table_name);
+                let table_path = Path::new(table_dir.as_str());
+                if table_path.exists() && table_path.is_dir() {
+                    println!("Removing directory / contents: {}", table_dir);
+                    let res = fs::remove_dir_all(table_path);
+                    match res {
+                        Ok(()) => {}
+                        Err(err) => return Err(Box::new(err)),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// Creates "tables" as specified in the event mapping configuration
+    /// These are just subdirs taht contain the synced files for that table / event
+    ///
+    pub async fn create_tables(&self) -> Result<(), Box<dyn Error>> {
+        for table_name in self.table_map.keys() {
+            // Check if table exists;  if NO, then create new
+            let table_dir = format!("{}/{}/", self.data_directory, table_name);
+            let table_path = Path::new(table_dir.as_str());
+            if !table_path.exists() {
+                println!("Creating directory: {}", table_name);
+                let res = fs::create_dir(table_path);
+                match res {
+                    Ok(()) => {}
+                    Err(err) => return Err(Box::new(err)),
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn write_csv_to_storage(&self, table_name: &str, csv_writer: &CsvWriter) {
+        // Given CSV, read into type-constrained / enforced polars dataframe
+        // Write out to parquet file, using block boundaries in file name
+        let column_map = &self.table_map[table_name];
+        let mut dataframe = read_csv_to_polars(csv_writer.path(), column_map);
+        let block_boundaries = self.get_block_boundaries(&dataframe);
+
+        //  Write to parquet file
+        match block_boundaries {
+            Err(err) => println!("Failed to write to parquet - reason: {:?}", err),
+            Ok((min, max)) => {
+                let parquet_file_name = format!("{}___{}_{}", table_name, min, max);
+                let full_path_name = format!(
+                    "{}/{}/{}",
+                    self.data_directory, table_name, parquet_file_name
+                );
+                println!("Writing parquet file: {}", full_path_name);
+
+                let parquet_file = File::create(full_path_name.as_str());
+                match parquet_file {
+                    Err(err) => {
+                        println!("Could not create file: {}, err: {:?}", full_path_name, err)
+                    }
+                    Ok(file) => {
+                        // Write file using parquet writer
+                        let res = ParquetWriter::new(file).finish(&mut dataframe);
+                        match res {
+                            Err(response) => {
+                                println!("Failed to write parquet file, reason: {:?}", response)
+                            }
+                            Ok(_) => println!("Successfully wrote parquet file."),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn get_block_boundaries(&self, dataframe: &DataFrame) -> Result<(i64, i64), PolarsError> {
+        let block_number_column = dataframe.column("block_number")?;
+        let min = block_number_column
+            .min()
+            .expect("No minimum block number found.");
+        let max = block_number_column
+            .max()
+            .expect("No maximum block number found.");
+        Ok((min, max))
+    }
+}
+
+///
+/// Implement DatasourceWritable wrapper
+#[async_trait]
+impl DatasourceWritable for ParquetClient {
+    async fn write_data(&self, table_name: &str, csv_writer: &CsvWriter) {
+        println!("  writing / sync to parquet file: {:?}", table_name);
+        self.write_csv_to_storage(table_name, csv_writer).await;
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/parquet.rs
+++ b/src/parquet.rs
@@ -1,0 +1,12 @@
+use crate::{
+    csv::CsvWriter,
+    datasource::DatasourceWritable,
+    types::{IndexerContractMapping, IndexerGcpBigQueryConfig},
+};
+use async_trait::async_trait;
+use csv::ReaderBuilder;
+use indexmap::IndexMap;
+use phf::phf_ordered_map;
+use polars::prelude::*;
+use serde_json::Value;
+use std::{any::Any, collections::HashMap, error::Error, fs::File};

--- a/src/parquet.rs
+++ b/src/parquet.rs
@@ -93,8 +93,7 @@ impl ParquetClient {
                 let table_path = Path::new(table_dir.as_str());
                 if table_path.exists() && table_path.is_dir() {
                     println!("Removing directory / contents: {}", table_dir);
-                    let res = fs::remove_dir_all(table_path);
-                    if let Err(err) = res {
+                    if let Err(err) = fs::remove_dir_all(table_path) {
                         return Err(Box::new(err));
                     }
                 }
@@ -115,10 +114,8 @@ impl ParquetClient {
             let table_path = Path::new(table_dir.as_str());
             if !table_path.exists() {
                 println!("Creating directory: {}", table_name);
-                let res = fs::create_dir(table_path);
-                match res {
-                    Ok(()) => {}
-                    Err(err) => return Err(Box::new(err)),
+                if let Err(err) = fs::create_dir(table_path) {
+                    return Err(Box::new(err));
                 }
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -136,6 +136,7 @@ pub struct IndexerConfig {
     pub gcp_bigquery: Option<IndexerGcpBigQueryConfig>,
 
     /// parquet configuration, if exists
+    #[serde(rename = "parquet", skip_serializing_if = "Option::is_none")]
     pub parquet: Option<IndexerParquetConfig>,
 
     /// The list of contract mappings.

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,7 +97,18 @@ pub struct IndexerGcpBigQueryConfig {
     pub credentials_path: String,
 }
 
-/// Represents the configuration for the Indexer.
+#[derive(Debug, Deserialize)]
+pub struct IndexerParquetConfig {
+    #[serde(rename = "dropTableBeforeSync")]
+    pub drop_tables: bool,
+
+    #[serde(rename = "dataDirectory")]
+    pub data_directory: String,
+
+    #[serde(rename = "usePyArrow")]
+    pub use_py_arrow: bool,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct IndexerConfig {
     /// The location of the rethDB.
@@ -126,6 +137,9 @@ pub struct IndexerConfig {
     /// GCP configuration, if exists
     #[serde(rename = "gcpBigQuery", skip_serializing_if = "Option::is_none")]
     pub gcp_bigquery: Option<IndexerGcpBigQueryConfig>,
+
+    /// parquet configuration, if exists
+    pub parquet: Option<IndexerParquetConfig>,
 
     /// The list of contract mappings.
     #[serde(rename = "eventMappings")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -104,9 +104,6 @@ pub struct IndexerParquetConfig {
 
     #[serde(rename = "dataDirectory")]
     pub data_directory: String,
-
-    #[serde(rename = "usePyArrow")]
-    pub use_py_arrow: bool,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Add ability to write to local parquet file(s) within the existing reth-indexer multi-datasource framework. 

Utilize polars dataframe construction and serialization to fast-write to parquet format.

Generalize some type and column name components written for GCP to be utilized in parquet writer (+ can be used in other writers / formats in future). 

Linked to issue: https://github.com/joshstevens19/reth-indexer/issues/38